### PR TITLE
Updated bench2graph to have graph title as the third arg instead of a prompt

### DIFF
--- a/bench2graph
+++ b/bench2graph
@@ -6,11 +6,12 @@
 # Thanks to Julian T J Midgley <jtjm@xenoclast.org>
 #
 
-if [ $# -lt 2 ] ; then
+if [ $# -lt 3 ] ; then
     echo "Usage          : bench2graph PARAM_1 PARAM_2 [ PARAM_3 ... PARAM_N ]"
     echo "Parameter 1    : autobench results file"
     echo "Parameter 2    : name of the postscript output file"
-    echo "Parameter 3..N : [optional] columns to display in the graphic"
+    echo "Parameter 3    : title of graph"
+    echo "Parameter 4..N : [optional] columns to display in the graphic"
     exit 1
 fi
 
@@ -33,14 +34,14 @@ if [ `echo $output |cut -c 1` != '/' ] ; then
 fi
 shift
 
+title=$1
+
+shift 
+
 while [ $# -ne 0 ] ; do
     liste="$liste,$1,"
     shift
 done
-
-
-echo -n "Enter the title : "
-read title
 
 if [ ! -d /tmp/graph_script ] ; then
     mkdir /tmp/graph_script

--- a/bench2graph.1
+++ b/bench2graph.1
@@ -20,7 +20,7 @@
 .SH NAME
 bench2graph \- draws Postscript graphs from Autobench output (using gnuplot)
 .SH SYNOPSIS
-.BR "bench2graph \fIfile\fR \fIoutfile\fR [\fIcol1\fR \fIcol2\fR \fIcol3\fR...]"
+.BR "bench2graph \fIfile\fR \fIoutfile\fR \fItitle\fR [\fIcol1\fR \fIcol2\fR \fIcol3\fR...]"
 .SH DESCRIPTION
 .B bench2graph
 takes a TSV format autobench results file, and uses gnuplot to graph
@@ -28,6 +28,7 @@ the results, producing output in Postscript.
 
 \fIfile\fR should be the name of the autobench results file.
 \fIoutfile\fR is the name of the file in which to store the output.
+\fItitle\fR is the title of the graph.
 
 Optionally, you can specify which of the columns in the autobench
 results file should be plotted, eg:


### PR DESCRIPTION
So, I've been using Autobench for a class assignment, testing a web server. It's been handy to pass the title of the graph as an argument rather than being prompted for it, so figured I could pass it along, see if anyone else would be interested.
